### PR TITLE
fix: filled missing values with 0, added DADA2 for single end data

### DIFF
--- a/.tests/config/config.yaml
+++ b/.tests/config/config.yaml
@@ -132,8 +132,8 @@ diversity:
     phylogeny-metric: 'weighted_normalized_unifrac'
     # Perform variance adjustment based on Chang et al. BMC Bioinformatics 2011
     phylogeny-variance-adjusted: True
-# If jan-mode is set to true, these parameters are used for denoising and clustering with DADA2
-dada2:
+# If jan-mode is set to true, these parameters are used for denoising and clustering paired-end-data with DADA2
+dada2-paired:
   # Position at which forward reads should be truncated at the 3' end due to low quality
   trunc-len-f: 240
   # Position at which reverse reads should be truncated at the 3' end due to low quality
@@ -150,6 +150,25 @@ dada2:
   trunc-q: 5
   # The minimum length of the overlap required for merging the forward and reverse reads
   min-overlap: 12
+  # The method used to pool samples for denoising ('independent', 'pseudo')
+  pooling-method: 'independent'
+  # The method used to remove chimeras ('none', 'consensus', 'pooled')
+  chimera-method: 'consensus'
+  # The minimum abundance of potential parents of a sequence being tested as chimeric, expressed as a 
+  # fold-change versus the abundance of the sequence being tested
+  min-fold-parent-over-abundance: 1.0
+  # The number of reads to use when training the errormodel
+  n-reads-learn: 1000000
+# If jan-mode is set to true, these parameters are used for denoising and clustering single-end-data with DADA2
+dada2-single:
+  # Position at which reads should be truncated at the 3' end due to low quality
+  trunc-len: 240
+  # Position at which reads should be truncated at the 5' end due to low quality
+  trim-left: 10
+  # Reads with number of expected errors higher than this value will be discarded
+  max-ee: 2.0
+  # Reads are truncated at the first instance of a quality score less than or equal to this value
+  trunc-q: 5
   # The method used to pool samples for denoising ('independent', 'pseudo')
   pooling-method: 'independent'
   # The method used to remove chimeras ('none', 'consensus', 'pooled')

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -132,8 +132,8 @@ diversity:
     phylogeny-metric: 'weighted_normalized_unifrac'
     # Perform variance adjustment based on Chang et al. BMC Bioinformatics 2011
     phylogeny-variance-adjusted: True
-# If jan-mode is set to true, these parameters are used for denoising and clustering with DADA2
-dada2:
+# If jan-mode is set to true, these parameters are used for denoising and clustering paired-end-data with DADA2
+dada2-paired:
   # Position at which forward reads should be truncated at the 3' end due to low quality
   trunc-len-f: 240
   # Position at which reverse reads should be truncated at the 3' end due to low quality
@@ -150,6 +150,25 @@ dada2:
   trunc-q: 5
   # The minimum length of the overlap required for merging the forward and reverse reads
   min-overlap: 12
+  # The method used to pool samples for denoising ('independent', 'pseudo')
+  pooling-method: 'independent'
+  # The method used to remove chimeras ('none', 'consensus', 'pooled')
+  chimera-method: 'consensus'
+  # The minimum abundance of potential parents of a sequence being tested as chimeric, expressed as a 
+  # fold-change versus the abundance of the sequence being tested
+  min-fold-parent-over-abundance: 1.0
+  # The number of reads to use when training the errormodel
+  n-reads-learn: 1000000
+# If jan-mode is set to true, these parameters are used for denoising and clustering single-end-data with DADA2
+dada2-single:
+  # Position at which reads should be truncated at the 3' end due to low quality
+  trunc-len: 240
+  # Position at which reads should be truncated at the 5' end due to low quality
+  trim-left: 10
+  # Reads with number of expected errors higher than this value will be discarded
+  max-ee: 2.0
+  # Reads are truncated at the first instance of a quality score less than or equal to this value
+  trunc-q: 5
   # The method used to pool samples for denoising ('independent', 'pseudo')
   pooling-method: 'independent'
   # The method used to remove chimeras ('none', 'consensus', 'pooled')

--- a/workflow/rules/filtering.smk
+++ b/workflow/rules/filtering.smk
@@ -120,7 +120,10 @@ if config["jan-mode"] == False:
             "--verbose 2> {log}"
 
 
-if config["jan-mode"] == True:
+if (
+    config["datatype"] == "SampleData[PairedEndSequencesWithQuality]"
+    and config["jan-mode"] == True
+):
 
     rule dada2:
         input:
@@ -130,20 +133,20 @@ if config["jan-mode"] == True:
             seq="results/{date}/out/seq-cluster-lengthfilter.qza",
             stats="results/{date}/out/dada2-stats.qza",
         params:
-            trunc_len_f=config["dada2"]["trunc-len-f"],
-            trunc_len_r=config["dada2"]["trunc-len-r"],
-            trim_left_f=config["dada2"]["trim-left-f"],
-            trim_left_r=config["dada2"]["trim-left-r"],
-            max_ee_f=config["dada2"]["max-ee-f"],
-            max_ee_r=config["dada2"]["max-ee-r"],
-            trunc_q=config["dada2"]["trunc-q"],
-            min_overlap=config["dada2"]["min-overlap"],
-            pooling_method=config["dada2"]["pooling-method"],
-            chimera_method=config["dada2"]["chimera-method"],
-            min_fold_parent_over_abundance=config["dada2"][
+            trunc_len_f=config["dada2-paired"]["trunc-len-f"],
+            trunc_len_r=config["dada2-paired"]["trunc-len-r"],
+            trim_left_f=config["dada2-paired"]["trim-left-f"],
+            trim_left_r=config["dada2-paired"]["trim-left-r"],
+            max_ee_f=config["dada2-paired"]["max-ee-f"],
+            max_ee_r=config["dada2-paired"]["max-ee-r"],
+            trunc_q=config["dada2-paired"]["trunc-q"],
+            min_overlap=config["dada2-paired"]["min-overlap"],
+            pooling_method=config["dada2-paired"]["pooling-method"],
+            chimera_method=config["dada2-paired"]["chimera-method"],
+            min_fold_parent_over_abundance=config["dada2-paired"][
                 "min-fold-parent-over-abundance"
             ],
-            n_reads_learn=config["dada2"]["n-reads-learn"],
+            n_reads_learn=config["dada2-paired"]["n-reads-learn"],
             threads=config["threads"],
         log:
             "logs/{date}/clustering/dada2.log",
@@ -160,6 +163,52 @@ if config["jan-mode"] == True:
             "--p-max-ee-r {params.max_ee_r} "
             "--p-trunc-q {params.trunc_q} "
             "--p-min-overlap {params.min_overlap} "
+            "--p-pooling-method {params.pooling_method} "
+            "--p-chimera-method {params.chimera_method} "
+            "--p-min-fold-parent-over-abundance {params.min_fold_parent_over_abundance} "
+            "--p-n-threads {params.threads} "
+            "--p-n-reads-learn {params.n_reads_learn} "
+            "--o-table {output.table} "
+            "--o-representative-sequences {output.seq} "
+            "--o-denoising-stats {output.stats} "
+            "--verbose 2> {log}"
+
+
+if (
+    config["datatype"] == "SampleData[SequencesWithQuality]"
+    and config["jan-mode"] == True
+):
+
+    rule dada2:
+        input:
+            "results/{date}/out/trimmed-seqs.qza",
+        output:
+            table="results/{date}/out/table-cluster-lengthfilter.qza",
+            seq="results/{date}/out/seq-cluster-lengthfilter.qza",
+            stats="results/{date}/out/dada2-stats.qza",
+        params:
+            trunc_len=config["dada2-single"]["trunc-len"],
+            trim_left=config["dada2-single"]["trim-left"],
+            max_ee=config["dada2-single"]["max-ee"],
+            trunc_q=config["dada2-single"]["trunc-q"],
+            pooling_method=config["dada2-single"]["pooling-method"],
+            chimera_method=config["dada2-single"]["chimera-method"],
+            min_fold_parent_over_abundance=config["dada2-single"][
+                "min-fold-parent-over-abundance"
+            ],
+            n_reads_learn=config["dada2-single"]["n-reads-learn"],
+            threads=config["threads"],
+        log:
+            "logs/{date}/clustering/dada2.log",
+        conda:
+            "../envs/qiime-only-env.yaml"
+        shell:
+            "qiime dada2 denoise-paired "
+            "--i-demultiplexed-seqs {input} "
+            "--p-trunc-len {params.trunc_len_f} "
+            "--p-trim-left {params.trim_left_f} "
+            "--p-max-ee {params.max_ee_f} "
+            "--p-trunc-q {params.trunc_q} "
             "--p-pooling-method {params.pooling_method} "
             "--p-chimera-method {params.chimera_method} "
             "--p-min-fold-parent-over-abundance {params.min_fold_parent_over_abundance} "

--- a/workflow/scripts/create_sample_metadata.py
+++ b/workflow/scripts/create_sample_metadata.py
@@ -62,11 +62,8 @@ for name in sample_list:
         print("No metadata was found for " + name)
         sample_list.remove(name)
         # Also remove the fastq file from folder?
-# Replacing empty metadata-columns with "NaN" and after that removing them from the file
-# Only columns holding information should be added to the sample-metadata-sheet
-nan_value = float("NaN")
-metadata.replace("", nan_value, inplace=True)
-metadata.dropna(how="any", axis=1, inplace=True)
+# Replacing empty metadata-columns with 0 and after that removing them from the file
+metadata.fillna(0, inplace=True)
 metadata.rename(columns={"sample_name": "sample-ID"}, inplace=True)
 metadata.to_csv(snakemake.output.metadata, sep="\t", index=False)
 


### PR DESCRIPTION

# Description

<!-- Add a more detailed description of the changes if needed. --> Missing values are now set to 0, so that bet-correlation can still be performed on the data without error. If the data to be processed is single-end, then DADA2 clustering for that kind of analysis is now possible.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->