### PR TITLE
fix: compressed kraken output

### DIFF
--- a/workflow/rules/outputs.smk
+++ b/workflow/rules/outputs.smk
@@ -201,6 +201,24 @@ rule snakemake_report:
         " --report {output} {params.for_testing}"
 
 
+rule compress_kraken:
+    input:
+        expand(
+            "results/{{date}}/out/kraken/{sample}.kreport2",
+            sample=get_reads_for_kraken(),
+        ),
+    output:
+        "results/{date}/out/kraken.tar.gz",
+    params:
+        directory="results/{date}/out/kraken/",
+    log:
+        "logs/{date}/outputs/kraken-compress.log",
+    conda:
+        "../envs/snakemake.yaml"
+    shell:
+        "tar -czvf {output} {params.directory} "
+
+
 rule zip_report:
     input:
         "results/{date}/visual/table-cluster-lengthfilter.qzv",
@@ -219,10 +237,7 @@ rule zip_report:
         "results/{date}/visual/fastq_stats.qzv",
         "results/{date}/out/table.from_biom_w_taxonomy-featcount.txt",
         "results/{date}/visual/absolute-taxabar-plot.png",
-        expand(
-            "results/{{date}}/out/kraken/{sample}.kreport2",
-            sample=get_reads_for_kraken(),
-        ),
+        "results/{date}/out/kraken.tar.gz",
         "results/{date}/out/alpha-diversity.qza",
         "results/{date}/out/beta-diversity-distance.qza",
         expand(


### PR DESCRIPTION
# Description

<!-- Add a more detailed description of the changes if needed. --> Kraken reports are now compressed into a file in the report and won't be shown seperately.

<!--
## Conventional Commits Format

(`<type>[optional scope]: <description>`)

## Type of Changes

- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- **docs**: Documentation only changes
- **feat**: A new feature
- **fix**: A bug fix
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **test**: Adding missing tests or correcting existing tests
-->